### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# fluent-plugin-numeric-counter, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-numeric-counter
 
 ## Component
 
 ### NumericCounterOutput
 
-Fluentd plugin to count messages, matches for numeric range patterns, and emits its result (like fluent-plugin-datacounter).
+[Fluentd](http://fluentd.org) plugin to count messages, matches for numeric range patterns, and emits its result (like fluent-plugin-datacounter).
 
 - Counts per min/hour/day
 - Counts per second (average every min/hour/day)


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
